### PR TITLE
fix: modify original electric tiles to match modifications done by py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Adds electric tile variants for all Pyanodons tiles. Each electric tile variant is unlocked at the same tech as the base tile.
 
+Also fixes the original electric tiles to have the same movement speed/vehicle properties as the corresponding tiles modified by Pynanodons.
+
 ## Legal Notice
 
 Pyanodons Electric Tiles is not officially endorsed or recognised by Pyanodons INC.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - Change original electric tile properties to match their corresponding base tile as modified by Pyanodons.
   Features:
     - Add electric tile variants to all Pyanodons tiles and unlock at the same time as the base tile.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,6 @@
+-- Electric Tiles
+require("prototypes.tiles.electric-tiles")
+
 -- pY Industry
 require("prototypes.tiles.py-asphalt")
 require("prototypes.tiles.py-limestone")

--- a/prototypes/tiles/electric-tiles.lua
+++ b/prototypes/tiles/electric-tiles.lua
@@ -1,0 +1,13 @@
+for _, tile in pairs {
+  "stone-path",
+  "concrete",
+  "refined-concrete",
+  "hazard-concrete-left",
+  "hazard-concrete-right",
+  "refined-hazard-concrete-left",
+  "refined-hazard-concrete-right",
+} do
+  data.raw.tile[ElectricTilesDataInterface.getTilePrefix() .. tile].walking_speed_modifier = data.raw.tile[tile].walking_speed_modifier
+  data.raw.tile[ElectricTilesDataInterface.getTilePrefix() .. tile].vehicle_friction_modifier = data.raw.tile[tile].vehicle_friction_modifier
+  data.raw.tile[ElectricTilesDataInterface.getTilePrefix() .. tile].decorative_removal_probability = data.raw.tile[tile].decorative_removal_probability
+end


### PR DESCRIPTION
This sets the walking speed, vehicle friction and other properties to be the same as set by py.