### PR TITLE
fix: electric tiles tech uses same science packs as concrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Adds electric tile variants for all Pyanodons tiles. Each electric tile variant is unlocked at the same tech as the base tile.
 
-Also fixes the original electric tiles to have the same movement speed/vehicle properties as the corresponding tiles modified by Pynanodons.
+Also fixes the original electric tiles to have the same movement speed/vehicle properties as the corresponding tiles modified by Pynanodons and modifies the electric tiles tech to use the same science packs as concrete.
 
 ## Legal Notice
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 1.0.0
 Date: ????
   Changes:
+    - Make electric tiles use the same science packs as concrete.
     - Change original electric tile properties to match their corresponding base tile as modified by Pyanodons.
   Features:
     - Add electric tile variants to all Pyanodons tiles and unlock at the same time as the base tile.

--- a/prototypes/tiles/electric-tiles.lua
+++ b/prototypes/tiles/electric-tiles.lua
@@ -11,3 +11,6 @@ for _, tile in pairs {
   data.raw.tile[ElectricTilesDataInterface.getTilePrefix() .. tile].vehicle_friction_modifier = data.raw.tile[tile].vehicle_friction_modifier
   data.raw.tile[ElectricTilesDataInterface.getTilePrefix() .. tile].decorative_removal_probability = data.raw.tile[tile].decorative_removal_probability
 end
+
+-- Make electric tiles use the same science packs as concrete
+data.raw.technology["electric-tiles-tech"].unit = data.raw.technology["concrete"].unit


### PR DESCRIPTION
Should be similar to Vanilla were electric tiles can also be unlocked with the same science packs as concrete.