### PR TITLE
feat: add support for tile-upgrade-planner-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Adds electric tile variants for all Pyanodons tiles. Each electric tile variant 
 
 Also fixes the original electric tiles to have the same movement speed/vehicle properties as the corresponding tiles modified by Pynanodons and modifies the electric tiles tech to use the same science packs as concrete.
 
+Use the [Tile Upgrade Planner Redux](https://mods.factorio.com/mod/tile-upgrade-planner-redux) to quickly update all existing tiles to their electric variants.
+
 ## Legal Notice
 
 Pyanodons Electric Tiles is not officially endorsed or recognised by Pyanodons INC.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@ Date: ????
     - Change original electric tile properties to match their corresponding base tile as modified by Pyanodons.
   Features:
     - Add electric tile variants to all Pyanodons tiles and unlock at the same time as the base tile.
+    - Supports Tile Ugrade Planner Redux to quickly upgrade base tiles to electric variants.

--- a/control.lua
+++ b/control.lua
@@ -1,0 +1,1 @@
+require("scripts.remote-interfaces.tile-upgrade-planner-redux")

--- a/info.json
+++ b/info.json
@@ -9,6 +9,7 @@
     "dependencies": [
         "base >= 2.0.60",
         "electric-tiles >= 1.2.8",
+        "? tile-upgrade-planner-redux >= 2.2.0",
 
         "? pyalienlife >= 3.0.0",
         "? pyalternativeenergy >= 3.0.0",

--- a/scripts/remote-interfaces/tile-upgrade-planner-redux.lua
+++ b/scripts/remote-interfaces/tile-upgrade-planner-redux.lua
@@ -1,0 +1,41 @@
+remote.add_interface("pyelectrictiles", {
+  tile_upgrade_planner_preset_addons = function()
+    return {
+      ["pY Electric Tiles: pY Industry"] = {
+        required_mods = {"pyelectrictiles", "pyindustry"},
+        tile_mappings = {
+          {source = "py-asphalt", target = "F077ET-py-asphalt"},
+          {source = "py-limestone", target = "F077ET-py-limestone"},
+          {source = "py-coal-tile", target = "F077ET-py-coal-tile"},
+          {source = "py-iron", target = "F077ET-py-iron"},
+          {source = "py-steel", target = "F077ET-py-steel"},
+          {source = "py-aluminium", target = "F077ET-py-aluminium"},
+        },
+      },
+      ["pY Electric Tiles: pY Industry & pY Alternative Energy"] = {
+        required_mods = {"pyelectrictiles", "pyindustry", "pyalternativeenergy"},
+        tile_mappings = {
+          {source = "lab-white", target = "F077ET-lab-white"},
+          {source = "red-refined-concrete", target = "F077ET-red-refined-concrete"},
+          {source = "green-refined-concrete", target = "F077ET-green-refined-concrete"},
+          {source = "blue-refined-concrete", target = "F077ET-blue-refined-concrete"},
+          {source = "orange-refined-concrete", target = "F077ET-orange-refined-concrete"},
+          {source = "yellow-refined-concrete", target = "F077ET-yellow-refined-concrete"},
+          {source = "pink-refined-concrete", target = "F077ET-pink-refined-concrete"},
+          {source = "purple-refined-concrete", target = "F077ET-purple-refined-concrete"},
+          {source = "black-refined-concrete", target = "F077ET-black-refined-concrete"},
+          {source = "brown-refined-concrete", target = "F077ET-brown-refined-concrete"},
+          {source = "cyan-refined-concrete", target = "F077ET-cyan-refined-concrete"},
+          {source = "acid-refined-concrete", target = "F077ET-acid-refined-concrete"},
+        },
+      },
+      ["pY Electric Tiles: pY Industry & pY Coal Processing"] = {
+        required_mods = {"pyelectrictiles", "pyindustry", "pycoalprocessing"},
+        tile_mappings = {
+          {source = "py-iron-oxide", target = "F077ET-py-iron-oxide"},
+          {source = "py-nexelit", target = "F077ET-py-nexelit"},
+        },
+      },
+    }
+  end
+})


### PR DESCRIPTION
This adds all electric tile variants as upgrade targets from their base tiles to the tile-upgrade-planner-redux mod.